### PR TITLE
added files to get recipe working with berkshelf and chef-solo

### DIFF
--- a/smartstack-solo.json
+++ b/smartstack-solo.json
@@ -1,0 +1,7 @@
+{
+    "run_list": [
+                  "recipe[smartstack::default]",
+                  "recipe[smartstack::nerve]",
+                  "recipe[smartstack::synapse]"
+                ]
+}

--- a/solo.rb
+++ b/solo.rb
@@ -1,0 +1,2 @@
+file_cache_path "/home/dubizzle/cache"
+cookbook_path  "/home/dubizzle/smartstack-cookbook/berks-cookbooks"


### PR DESCRIPTION
@aamirdb just added the files for chef-solo. Works on smartstack-dev.dubizzle.central which berkshelf and chef-solo.
added how-to to this wiki
