### PR TITLE
Allow configurable path to `service`

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,9 @@ default.smartstack.jar_source = "https://airbnb-public.s3.amazonaws.com/smartsta
 
 # you should override this in your environment with the real cluster
 default.zookeeper.smartstack_cluster = [ 'localhost:2181' ]
+
+default.smartstack.service_path = value_for_platform(
+  'centos' => { 'default' => '/sbin/service' },
+  'ubuntu' => { 'default' => '/usr/sbin/service' },
+  'default' => '/usr/sbin/service'
+)

--- a/recipes/synapse.rb
+++ b/recipes/synapse.rb
@@ -28,7 +28,7 @@ file File.join("/etc/sudoers.d", node.smartstack.user) do
   owner   "root"
   group   "root"
   mode    0440
-  content "#{node.smartstack.user} ALL= NOPASSWD: /usr/sbin/service haproxy reload\n"
+  content "#{node.smartstack.user} ALL= NOPASSWD: #{node.smartstack.service_path} haproxy reload\n"
 end
 
 # get the synapse code


### PR DESCRIPTION
Hello! First, thanks for this awesomely configurable cookbook. It has made it possible for me to find the joy of smartstack without needing to configure barely anything to begin with.

I know this cookbook is intended for Ubuntu audiences only, but we're looking at using it on CentOS. Only one snag to be found (so far?): the path to the service executable is different so SmartStack cannot restart haproxy.

This PR is a quick hack allowing a different path based on node['platform'], and for other platforms to be able to configure it via an attribute. I'd be happy to rewrite a different way if you think of a better way.

Also, is there a convenient way to run the test suite against this? I did some minimal verification locally but some continuous integration here could go a long way.

Thanks!
