### PR TITLE
Allow configurable runit_service cookbook

### DIFF
--- a/attributes/nerve.rb
+++ b/attributes/nerve.rb
@@ -15,6 +15,10 @@ default.nerve.enabled_services = []
 default.nerve.local.host = "127.0.0.1"
 default.nerve.local.port = 1025
 
+# Cookbook in which the runit_service LWRP will look for an sv-nerve-run.erb
+# template:
+default.nerve.runit_cookbook = 'smartstack'
+
 # everything below is used to configure nerve at runtime
 instance_id = node.hostname
 instance_id = node.ec2.instance_id if node.has_key? 'ec2'

--- a/attributes/synapse.rb
+++ b/attributes/synapse.rb
@@ -16,6 +16,10 @@ default.synapse.haproxy.sock_dir = '/var/haproxy'
 default.synapse.haproxy.sock_file = File.join(node.synapse.haproxy.sock_dir, 'stats.sock')
 default.synapse.haproxy.channel = 'local1'
 
+# Cookbook in which the runit_service LWRP will look for an sv-synapse-run.erb
+# template:
+default.synapse.runit_cookbook = 'smartstack'
+
 default.synapse.config = {
   'services' => {},
   'haproxy' => {

--- a/recipes/nerve.rb
+++ b/recipes/nerve.rb
@@ -85,5 +85,6 @@ end
 # so, we only enable nerve; setting it up initially causes it to start,
 runit_service 'nerve' do
   action :enable
+  cookbook node.nerve.runit_cookbook
   default_logger true
 end

--- a/recipes/synapse.rb
+++ b/recipes/synapse.rb
@@ -118,5 +118,6 @@ end
 # set up runit service
 runit_service "synapse" do
   action :enable
+  cookbook node.synapse.runit_cookbook
   default_logger true
 end


### PR DESCRIPTION
In our SmartStack wrapper cookbook, we want to modify the runit `sv-synapse-run` file so that it loads rbenv first. In order to do this, we need to modify the template beyond what the current attributes allow.

In order to satisfy this use-case, this adds an attribute allowing an arbitrary cookbook to provide that template.
