### PR TITLE
remove airbnb-public S3 bucket reference

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,8 +20,11 @@ Vagrant.configure("2") do |master_config|
 
   master_config.vm.define "smartstack" do |config|
     config.vm.box     = "smartstack"
-    config.vm.box_url = "https://airbnb-public.s3.amazonaws.com/vagrant-boxes/ubuntu12.04-chef11.4.4-vbox4210.box"
 
+    # The url from where the 'config.vm.box' box will be fetched if it
+    # doesn't already exist on the user's system.
+    # config.vm.box_url = "http://domain.com/path/to/above.box"
+    
     config.vm.network :private_network, ip: '172.16.1.3'
 
     config.vm.provider "virtualbox" do |v|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ include_attribute 'smartstack::services'
 default.smartstack.user = 'smartstack'
 default.smartstack.home = '/opt/smartstack'
 default.smartstack.gem_home = File.join(node.smartstack.home, '.gem')
-default.smartstack.jar_source = "https://airbnb-public.s3.amazonaws.com/smartstack"
+default.smartstack.jar_source = nil
 
 # you should override this in your environment with the real cluster
 default.zookeeper.smartstack_cluster = [ 'localhost:2181' ]

--- a/recipes/nerve.rb
+++ b/recipes/nerve.rb
@@ -8,7 +8,7 @@ directory node.nerve.home do
   recursive true
 end
 
-if node.nerve.jarname
+if node.smartstack.jar_source && node.nerve.jarname
   include_recipe 'java'
 
   url = "#{node.smartstack.jar_source}/nerve/#{node.nerve.jarname}"

--- a/recipes/synapse.rb
+++ b/recipes/synapse.rb
@@ -38,7 +38,7 @@ directory node.synapse.home do
   recursive true
 end
 
-if node.synapse.jarname
+if node.smartstack.jar_source && node.synapse.jarname
   include_recipe 'java'
 
   url = "#{node.smartstack.jar_source}/synapse/#{node.synapse.jarname}"


### PR DESCRIPTION
Airbnb no longer maintains S3 bucket `airbnb-public`. Remove the orphan reference to it.

@Jason-Jian 